### PR TITLE
feat: get token from cookies instead of body on refresh token

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -64,17 +64,19 @@ class TokenObtainPairViewWrapper(APIView):
 # setting refreshToken in cookies
 class TokenRefreshViewWrapper(APIView):
     def post(self, request):
-        serializer = TokenRefreshSerializer(data=request.data)
+        serializer = TokenRefreshSerializer(data={"refresh": request.COOKIES["refreshToken"]})
         if serializer.is_valid():
             response = Response(serializer.validated_data, status=status.HTTP_200_OK)
-            response.set_cookie(
-                key="refreshToken",
-                value=serializer.validated_data["refresh"],
-                httponly=True,
-                secure=True,
-                samesite="None",  # required if frontend and backend are on different domains
-                max_age=60 * 60 * 24 * 7  # example: 7 days
-            )
+
+            if ("refresh" in serializer.validated_data):
+                response.set_cookie(
+                    key="refreshToken",
+                    value=serializer.validated_data["refresh"],
+                    httponly=True,
+                    secure=True,
+                    samesite="None",  # required if frontend and backend are on different domains
+                    max_age=60 * 60 * 24 * 7  # example: 7 days
+                )
 
             return response
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Alterações feitas:

- Alterada obtenção de refresh token pelos cookies ao invés do body da request no endpoint de refresh token.
- Adicionada validação para retornar refresh token nos cookies da resposta do endpoint de refresh token apenas se retornado no objeto serializado.